### PR TITLE
Fix Java 6 compatibility issue in test case

### DIFF
--- a/src/test/java/com/spotify/netty/handler/codec/zmtp/ZMQIntegrationTest.java
+++ b/src/test/java/com/spotify/netty/handler/codec/zmtp/ZMQIntegrationTest.java
@@ -117,7 +117,7 @@ public class ZMQIntegrationTest {
   public void testZmqDealer() throws Exception {
     final ZMQ.Context context = ZMQ.context(1);
     final ZMQ.Socket socket = context.socket(ZMQ.DEALER);
-    socket.connect("tcp://" + serverAddress.getHostString() + ":" + serverAddress.getPort());
+    socket.connect("tcp://" + serverAddress.getHostName() + ":" + serverAddress.getPort());
     final ZMsg request = ZMsg.newStringMsg("envelope", "", "hello", "world");
     request.send(socket);
 
@@ -139,7 +139,7 @@ public class ZMQIntegrationTest {
   public void testZmqRouter() throws Exception {
     final ZMQ.Context context = ZMQ.context(1);
     final ZMQ.Socket socket = context.socket(ZMQ.ROUTER);
-    socket.connect("tcp://" + serverAddress.getHostString() + ":" + serverAddress.getPort());
+    socket.connect("tcp://" + serverAddress.getHostName() + ":" + serverAddress.getPort());
 
     final ZMTPMessage request = new ZMTPMessage(
         asList(ZMTPFrame.create("envelope")),


### PR DESCRIPTION
InetSocketAddress.getHostString() is Java 7 only, switching to .getHostName().
This may result in a PTR lookup, which shouldn't be a problem for a test case.
