### PR TITLE
Switch test dependency from zeromq to jeromq

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,9 +47,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.zeromq</groupId>
-      <artifactId>jzmq</artifactId>
-      <version>2.1.3</version>
+      <groupId>org.jeromq</groupId>
+      <artifactId>jeromq</artifactId>
+      <version>0.2.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/test/java/com/spotify/netty/handler/codec/zmtp/ZMTPFrameIntegrationTest.java
+++ b/src/test/java/com/spotify/netty/handler/codec/zmtp/ZMTPFrameIntegrationTest.java
@@ -18,9 +18,9 @@ package com.spotify.netty.handler.codec.zmtp;
 
 import org.jboss.netty.channel.ChannelFuture;
 import org.junit.Test;
-import org.zeromq.ZFrame;
-import org.zeromq.ZMQ;
-import org.zeromq.ZMsg;
+import org.jeromq.ZFrame;
+import org.jeromq.ZMQ;
+import org.jeromq.ZMsg;
 
 import java.util.UUID;
 

--- a/src/test/java/com/spotify/netty/handler/codec/zmtp/ZMTPTestConnector.java
+++ b/src/test/java/com/spotify/netty/handler/codec/zmtp/ZMTPTestConnector.java
@@ -25,7 +25,7 @@ import org.jboss.netty.channel.ChannelPipelineFactory;
 import org.jboss.netty.channel.Channels;
 import org.jboss.netty.channel.socket.nio.NioClientSocketChannelFactory;
 import org.jboss.netty.handler.codec.oneone.OneToOneDecoder;
-import org.zeromq.ZMQ;
+import org.jeromq.ZMQ;
 
 import java.net.InetSocketAddress;
 import java.util.concurrent.Executors;


### PR DESCRIPTION
While experimenting with an automated build system for our free software projects it turned out that the zeromq jar for some reason doesn't work in the test environment (for some reason the native component is missing). Looking around a bit it seems like we can perform the test with jeromq instead and remove the dependency on native code for running the test cases.

The changes are miminmal, just an explicit comparison of request and response since the equals() method on ZMsg seems to be missing.
