### PR TITLE
fix long frames in ZMTP 1.0

### DIFF
--- a/src/main/java/com/spotify/netty/handler/codec/zmtp/ZMTPUtils.java
+++ b/src/main/java/com/spotify/netty/handler/codec/zmtp/ZMTPUtils.java
@@ -41,6 +41,9 @@ public class ZMTPUtils {
    * @throws IndexOutOfBoundsException if there is not enough octets to be read.
    */
   static public long decodeLength(final ChannelBuffer in) {
+    if (in.readableBytes() < 1) {
+      return -1;
+    }
     long size = in.readByte() & 0xFF;
     if (size == 0xFF) {
       if (in.readableBytes() < 8) {

--- a/src/test/java/com/spotify/netty/handler/codec/zmtp/CodecTest.java
+++ b/src/test/java/com/spotify/netty/handler/codec/zmtp/CodecTest.java
@@ -46,4 +46,12 @@ public class CodecTest {
                         4, size);
   }
 
+  @Test
+  public void testZMTP1LenghtEmptyBuffer() {
+    ChannelBuffer buffer = ChannelBuffers.dynamicBuffer();
+    long size = ZMTPUtils.decodeLength(buffer);
+    Assert.assertEquals("Empty buffer should return -1 frame length",
+                        -1, size);
+  }
+
 }

--- a/src/test/java/com/spotify/netty/handler/codec/zmtp/ZMTPMessageParserTest.java
+++ b/src/test/java/com/spotify/netty/handler/codec/zmtp/ZMTPMessageParserTest.java
@@ -78,6 +78,15 @@ public class ZMTPMessageParserTest {
                msg);
   }
 
+  @Test
+  public void testZMTP1BufferLengthEmpty() throws ZMTPMessageParsingException {
+    ChannelBuffer buffer = ChannelBuffers.dynamicBuffer();
+    ZMTPMessageParser parser = new ZMTPMessageParser(false, 1024, 1);
+    ZMTPParsedMessage msg = parser.parse(buffer);
+    assertNull("Empty ChannelBuffer should result in an empty ZMTPParsedMessage",
+               msg);
+  }
+
   @DataPoints
   public static Parameters[] PARAMETERS = {
       test(input("1"), enveloped()),


### PR DESCRIPTION
Summary:
If the size is 255 that means that the real size is in the next 8 bytes
as a long. Problem is previously didn't check if the buffer has 8 more
bytes to read. This returns -1 which signals that the length isn't yet
readable and will cause parseZMTP1Header to return false. This will
cause parseMessage to resetReaderIndex back to the mark and to wait for
more bytes.
