### PR TITLE
parser: handle unenveloped messages

### DIFF
--- a/src/main/java/com/spotify/netty/handler/codec/zmtp/ZMTPMessage.java
+++ b/src/main/java/com/spotify/netty/handler/codec/zmtp/ZMTPMessage.java
@@ -107,27 +107,38 @@ public class ZMTPMessage {
    * Create a new message from a list of frames.
    */
   public static ZMTPMessage from(final boolean enveloped, final List<ZMTPFrame> frames) {
-    final List<ZMTPFrame> envelope;
-    final List<ZMTPFrame> content = new ArrayList<ZMTPFrame>();
+    final List<ZMTPFrame> head;
+    final List<ZMTPFrame> tail = new ArrayList<ZMTPFrame>();
+    boolean delimited = false;
     int i = 0;
     if (enveloped) {
-      envelope = new ArrayList<ZMTPFrame>();
+      head = new ArrayList<ZMTPFrame>();
       for (; i < frames.size(); i++) {
         final ZMTPFrame frame = frames.get(i);
         if (frame == EMPTY_FRAME) {
+          delimited = true;
           i++;
           break;
         }
-        envelope.add(frame);
+        head.add(frame);
       }
     } else {
-      envelope = Collections.emptyList();
+      head = Collections.emptyList();
     }
 
     for (; i < frames.size(); i++) {
-      content.add(frames.get(i));
+      tail.add(frames.get(i));
     }
 
+    final List<ZMTPFrame> envelope;
+    final List<ZMTPFrame> content;
+    if (enveloped && !delimited) {
+      envelope = Collections.emptyList();
+      content = head;
+    } else {
+      envelope = head;
+      content = tail;
+    }
     return new ZMTPMessage(envelope, content);
   }
 

--- a/src/test/java/com/spotify/netty/handler/codec/zmtp/ZMTPMessageTest.java
+++ b/src/test/java/com/spotify/netty/handler/codec/zmtp/ZMTPMessageTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2012-2014 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.spotify.netty.handler.codec.zmtp;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static com.spotify.netty.handler.codec.zmtp.ZMTPMessage.fromStringsUTF8;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+public class ZMTPMessageTest {
+
+  @Test
+  public void testFromStringsUTF8() {
+    assertEquals(fromStringsUTF8(true, ""), message(frames(), frames()));
+    assertEquals(fromStringsUTF8(true, "e", ""), message(frames("e"), frames()));
+    assertEquals(fromStringsUTF8(true, "e", "", "c"), message(frames("e"), frames("c")));
+    assertEquals(fromStringsUTF8(true, "e", "", "c1", "c2"), message(frames("e"), frames("c1", "c2")));
+    assertEquals(fromStringsUTF8(true, "c"), message(frames(), frames("c")));
+    assertEquals(fromStringsUTF8(true, "c1", "c2"), message(frames(), frames("c1", "c2")));
+
+    assertEquals(fromStringsUTF8(false, ""), message(frames(), frames("")));
+    assertEquals(fromStringsUTF8(false, "e", ""), message(frames(), frames("e", "")));
+    assertEquals(fromStringsUTF8(false, "e", "", "c"), message(frames(), frames("e", "", "c")));
+    assertEquals(fromStringsUTF8(false, "e", "", "c1", "c2"), message(frames(), frames("e", "", "c1", "c2")));
+    assertEquals(fromStringsUTF8(false, "c"), message(frames(), frames("c")));
+    assertEquals(fromStringsUTF8(false, "c1", "c2"), message(frames(), frames("c1", "c2")));
+  }
+
+  private ZMTPMessage message(final List<ZMTPFrame> envelope, final List<ZMTPFrame> content) {
+    return new ZMTPMessage(envelope, content);
+  }
+
+  public static List<ZMTPFrame> frames(final String... frames) {
+    return frames(asList(frames));
+  }
+
+  private static List<ZMTPFrame> frames(final List<String> frames) {
+    return Lists.transform(frames, new Function<String, ZMTPFrame>() {
+      @Override
+      public ZMTPFrame apply(final String input) {
+        return ZMTPFrame.create(input);
+      }
+    });
+  }
+}


### PR DESCRIPTION
If receiving a message without a delimiter in enveloped parsing mode,
interpret that as a message without an envelope instead of as a message
without content.

This allows the parser to consume messages on a connection where it is
not known if messages will be enveloped or not.

It could be argued that the parser should not attempt to deal with
envelope/content semantics at all and instead simply produce a single
list of frames, but that's a larger breaking change that will have to
be done later, if desired.
