### PR TITLE
travis: use docker build env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: java
+
 jdk:
   - oraclejdk8
   - oraclejdk7
   - openjdk6
   - openjdk7
+
+sudo: false

--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,14 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.18</version>
+        <configuration>
+            <argLine>-Xmx1g</argLine>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Also limit test memory usage. The docker build env likely reports the full memory amount of the physical host while the container itself is actually limited to 4gb, causing the jvm to gobble up ram and eventually getting killed.
