### PR TITLE
travis: use lxc env and 2 cores only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,3 @@ jdk:
   - oraclejdk7
   - openjdk6
   - openjdk7
-
-sudo: false

--- a/src/test/java/com/spotify/netty/handler/codec/zmtp/ZMTPMessageParserTest.java
+++ b/src/test/java/com/spotify/netty/handler/codec/zmtp/ZMTPMessageParserTest.java
@@ -67,7 +67,7 @@ import static org.junit.Assert.assertNull;
 @RunWith(Theories.class)
 public class ZMTPMessageParserTest {
 
-  public static final int CPUS = Runtime.getRuntime().availableProcessors();
+  public static final int CPUS = 2;
   public static final ExecutorService EXECUTOR = MoreExecutors.getExitingExecutorService(
       (ThreadPoolExecutor) Executors.newFixedThreadPool(CPUS), 0, SECONDS);
 


### PR DESCRIPTION
Testing this hypothesis: https://github.com/spotify/netty-zmtp/pull/23#issuecomment-65334563
