### PR TITLE
handshake: write from position in pipeline

### DIFF
--- a/src/main/java/com/spotify/netty/handler/codec/zmtp/MessageWriter.java
+++ b/src/main/java/com/spotify/netty/handler/codec/zmtp/MessageWriter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2012-2014 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.spotify.netty.handler.codec.zmtp;
+
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.channel.ChannelFuture;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.Channels;
+
+class MessageWriter {
+
+  private final ChannelHandlerContext ctx;
+
+  MessageWriter(final ChannelHandlerContext ctx) {
+    this.ctx = ctx;
+  }
+
+  ChannelFuture write(ChannelBuffer msg) {
+    final ChannelFuture future = Channels.future(ctx.getChannel());
+    Channels.write(ctx, future, msg);
+    return future;
+  }
+}

--- a/src/main/java/com/spotify/netty/handler/codec/zmtp/ZMTP10Codec.java
+++ b/src/main/java/com/spotify/netty/handler/codec/zmtp/ZMTP10Codec.java
@@ -2,7 +2,6 @@ package com.spotify.netty.handler.codec.zmtp;
 
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.buffer.ChannelBuffers;
-import org.jboss.netty.channel.Channel;
 
 /**
  * A ZMTP10Codec instance is a ChannelUpstreamHandler that, when placed in a ChannelPipeline,
@@ -28,7 +27,7 @@ public class ZMTP10Codec extends CodecBase {
   }
 
   @Override
-  boolean inputOutput(final ChannelBuffer buffer, final Channel channel) throws ZMTPException {
+  boolean inputOutput(final ChannelBuffer buffer, final MessageWriter out) throws ZMTPException {
     byte[] remoteIdentity = readZMTP1RemoteIdentity(buffer);
     if (listener != null) {
       listener.handshakeDone(1, remoteIdentity);

--- a/src/main/java/com/spotify/netty/handler/codec/zmtp/ZMTP20Codec.java
+++ b/src/main/java/com/spotify/netty/handler/codec/zmtp/ZMTP20Codec.java
@@ -2,7 +2,6 @@ package com.spotify.netty.handler.codec.zmtp;
 
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.buffer.ChannelBuffers;
-import org.jboss.netty.channel.Channel;
 
 /**
  * A ZMTP20Codec instance is a ChannelUpstreamHandler that, when placed in a ChannelPipeline,
@@ -36,7 +35,7 @@ public class ZMTP20Codec extends CodecBase {
   }
 
   @Override
-  boolean inputOutput(final ChannelBuffer buffer, final Channel channel) throws ZMTPException {
+  boolean inputOutput(final ChannelBuffer buffer, final MessageWriter out) throws ZMTPException {
     if (splitHandshake) {
       done(2, parseZMTP2Greeting(buffer, false));
       return true;
@@ -49,12 +48,12 @@ public class ZMTP20Codec extends CodecBase {
         buffer.resetReaderIndex();
         // when a ZMTP/1.0 peer is detected, just send the identity bytes. Together
         // with the compatibility signature it makes for a valid ZMTP/1.0 greeting.
-        channel.write(ChannelBuffers.wrappedBuffer(session.getLocalIdentity()));
+        out.write(ChannelBuffers.wrappedBuffer(session.getLocalIdentity()));
         done(version, ZMTP10Codec.readZMTP1RemoteIdentity(buffer));
         return true;
       } else {
         splitHandshake = true;
-        channel.write(makeZMTP2Greeting(false));
+        out.write(makeZMTP2Greeting(false));
         return false;
       }
     } else {
@@ -62,7 +61,6 @@ public class ZMTP20Codec extends CodecBase {
       return true;
     }
   }
-
 
   private void done(int version, byte[] remoteIdentity) {
     if (listener != null) {


### PR DESCRIPTION
Channel.write() will cause the outgoing message to pass through the
entire pipeline, including handlers behind the codec, which is
undesirable as those handlers do not expect to participate in the
handshake.
