### PR TITLE
Upgrade to more recent netty 4.1.60Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>1.6</maven.compiler.target>
-    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.7</maven.compiler.source>
   </properties>
 
   <developers>
@@ -49,10 +49,11 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
-      <version>4.0.34.Final</version>
+      <version>4.1.60.Final</version>
       <!-- the user of this lib should already have a dependency on netty -->
       <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
@@ -125,8 +126,8 @@
         <version>3.3</version>
         <configuration>
           <useIncrementalCompilation>false</useIncrementalCompilation>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/java/com/spotify/netty4/handler/codec/zmtp/ZMTPMessage.java
+++ b/src/main/java/com/spotify/netty4/handler/codec/zmtp/ZMTPMessage.java
@@ -27,6 +27,7 @@ import java.util.List;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.AbstractReferenceCounted;
+import io.netty.util.ReferenceCounted;
 import io.netty.util.internal.RecyclableArrayList;
 
 import static com.spotify.netty4.handler.codec.zmtp.ZMTPUtils.checkNotNull;
@@ -51,6 +52,11 @@ public class ZMTPMessage extends AbstractReferenceCounted implements Iterable<By
   @Override
   public ZMTPMessage retain(final int increment) {
     super.retain(increment);
+    return this;
+  }
+
+  @Override
+  public ReferenceCounted touch(Object hint) {
     return this;
   }
 

--- a/src/test/java/com/spotify/netty4/handler/codec/zmtp/ZMTPFramingEncoderTest.java
+++ b/src/test/java/com/spotify/netty4/handler/codec/zmtp/ZMTPFramingEncoderTest.java
@@ -2,6 +2,7 @@ package com.spotify.netty4.handler.codec.zmtp;
 
 import com.google.common.base.Strings;
 
+import io.netty.channel.Channel;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,6 +37,7 @@ public class ZMTPFramingEncoderTest {
   private final static ByteBufAllocator ALLOC = new UnpooledByteBufAllocator(false);
 
   @Mock ChannelHandlerContext ctx;
+  @Mock Channel channel;
   @Mock ChannelPromise promise;
   @Mock EventExecutor executor;
 
@@ -48,6 +50,7 @@ public class ZMTPFramingEncoderTest {
     when(ctx.write(bufCaptor.capture(), any(ChannelPromise.class))).thenReturn(promise);
     when(ctx.alloc()).thenReturn(ByteBufAllocator.DEFAULT);
     when(ctx.executor()).thenReturn(executor);
+    when(ctx.channel()).thenReturn(channel);
   }
 
   @Test

--- a/src/test/java/com/spotify/netty4/handler/codec/zmtp/benchmarks/CustomReqRepBenchmark.java
+++ b/src/test/java/com/spotify/netty4/handler/codec/zmtp/benchmarks/CustomReqRepBenchmark.java
@@ -37,6 +37,7 @@ import java.security.SecureRandom;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
@@ -54,7 +55,6 @@ import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
-import io.netty.util.internal.chmv8.ForkJoinPool;
 
 import static com.spotify.netty4.handler.codec.zmtp.ZMTPSocketType.DEALER;
 import static com.spotify.netty4.handler.codec.zmtp.ZMTPSocketType.ROUTER;


### PR DESCRIPTION
Upgrade to more recent netty (4.1.60Final), add unimplemented method, upgrade java so can use java.util.concurrent